### PR TITLE
Remove defaults for environment variables

### DIFF
--- a/azkeys/secretvault.go
+++ b/azkeys/secretvault.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/ethereum/go-ethereum/crypto"
 
-	env "github.com/rkvst/go-rkvstcommon/environment"
 	"github.com/rkvst/go-rkvstcommon/logger"
 )
 
@@ -47,13 +47,21 @@ func DefaultAuthorizer() autorest.Authorizer {
 	return autorest.NewBearerAuthorizer(tokenProvider)
 }
 
+func getWithDefault(key string) string {
+	val, ok := os.LookupEnv(key)
+	if ok {
+		return val
+	}
+	return "<notset>"
+}
+
 func EnvironmentAuthorizer() (autorest.Authorizer, error) {
 
 	logger.Sugar.Infof("Using env authorizer for keyvault")
-	logger.Sugar.Infof("AZURE_TENANT_ID: %s", env.GetWithDefault("AZURE_TENANT_ID", "<notset>"))
-	logger.Sugar.Infof("AZURE_CLIENT_ID: %s", env.GetWithDefault("AZURE_CLIENT_ID", "<notset>"))
+	logger.Sugar.Infof("AZURE_TENANT_ID: %s", getWithDefault("AZURE_TENANT_ID"))
+	logger.Sugar.Infof("AZURE_CLIENT_ID: %s", getWithDefault("AZURE_CLIENT_ID"))
 	// We do not use the env auhtorizer in production
-	logger.Sugar.Infof("AZURE_CLIENT_SECRET: %s", env.GetWithDefault("AZURE_CLIENT_SECRET", "<notset>"))
+	logger.Sugar.Infof("AZURE_CLIENT_SECRET: %s", getWithDefault("AZURE_CLIENT_SECRET"))
 
 	return auth.NewAuthorizerFromEnvironment()
 }

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -24,39 +24,11 @@ func GetLogLevel() string {
 	return value
 }
 
-// GetWithDefault returns value of environment variable.
-// If the environment variable does not exist or is empty,
-// then the default value is returned.
-func GetWithDefault(key, fallback string) string {
-	value, ok := os.LookupEnv(key)
-	if !ok {
-		value = fallback
-	}
-	return value
-}
-
 // GetOrFatal returns the key's value or logs a Fatal error (and exits)
 func GetOrFatal(key string) string {
 	value, ok := os.LookupEnv(key)
 	if !ok {
 		logger.Sugar.Panicf("required environment variable is not defined: %s", key)
-	}
-	return value
-}
-
-// GetIntWithDefault returns value of environment variable that is
-// expected to be an int.
-// If the environment variable does not exist or is incorrect,
-// then the default value is returned.
-func GetIntWithDefault(key string, fallback int) int {
-	val, ok := os.LookupEnv(key)
-	if !ok {
-		return fallback
-	}
-	value, err := strconv.Atoi(val)
-	if err != nil {
-		logger.Sugar.Infof("`%s' can not be converted to an integer. defaulting to %v. err=%v", key, fallback, err)
-		return fallback
 	}
 	return value
 }
@@ -84,21 +56,6 @@ func GetRequired(key string) (string, error) {
 	return value, nil
 }
 
-// GetTruthy returns true if key is set to a value that is truthy. Returns
-// false otherwise.
-func GetTruthy(key string) bool {
-	value, ok := os.LookupEnv(key)
-	if !ok {
-		return false
-	}
-	// t,true,True,1 are all examples of 'truthy' values understood by ParseBool
-	b, err := strconv.ParseBool(value)
-	if err != nil {
-		return false
-	}
-	return b
-}
-
 // GetTruthyOrFatal returns true if key is set to a value that is truthy. Returns
 // false otherwise.
 func GetTruthyOrFatal(key string) bool {
@@ -122,24 +79,13 @@ func GetTruthyOrFatal(key string) bool {
 //
 //	as the only element in the list
 func GetListOrFatal(key string) []string {
+	const commaSeparator = ","
 	if value, ok := os.LookupEnv(key); ok {
 		values := strings.Split(value, commaSeparator)
 		return values
 	}
 	logger.Sugar.Panicf("required environment variable is not defined: %s", key)
 	return []string{} // never reaches here
-}
-
-// ReadWithDefaultOrFatal like ReadFileWithDefaultOrFatal but the file name
-// is supplied in the named environment variable. Additionally, If the env var
-// is not set the defaultValue is returned
-func ReadWithDefaultOrFatal(varname, defaultValue string) string {
-	filename, ok := os.LookupEnv(varname)
-	if !ok {
-		logger.Sugar.Infof("environment variable `%s' not found, returning default", varname)
-		return defaultValue
-	}
-	return ReadFileWithDefaultOrFatal(filename, defaultValue)
 }
 
 // ReadIndirectOrFatal reads filename and uses it to read a value from the file.
@@ -154,40 +100,4 @@ func ReadIndirectOrFatal(varname string) string {
 		logger.Sugar.Panicf("error reading file `%s': %s", filename, err)
 	}
 	return string(b)
-}
-
-// ReadFileOrFatal reads file or raises Fatal on error
-func ReadFileOrFatal(filename string) string {
-	var b []byte
-	var err error
-	if b, err = os.ReadFile(filename); err != nil {
-		logger.Sugar.Panicf("failed to read `%s': %v", filename, err)
-	}
-	return string(b)
-}
-
-// ReadFileWithDefaultOrFatal as per ReadWithDefault but fatal on any err other
-// than "file not exists".
-func ReadFileWithDefaultOrFatal(filename, value string) string {
-	value, err := readFileWithDefault(filename, value)
-	if err != nil {
-		logger.Sugar.Panicf("failed to read `%s': %v", filename, err)
-	}
-	return value
-}
-
-// ReadFileWithDefault returns the contents of the file as a string if the file
-// exists. If the file does not exist, returns value. Any error other than
-// 'file not exist' occurs is returned. value is returned in all error cases.
-func readFileWithDefault(filename, value string) (string, error) {
-	var b []byte
-	var err error
-	if b, err = os.ReadFile(filename); err != nil {
-		if os.IsNotExist(err) {
-			logger.Sugar.Infof("filename `%s' does not exist, returning default `%s'", filename, value)
-			return value, nil
-		}
-		return value, err
-	}
-	return string(b), nil
 }

--- a/environment/environment_test.go
+++ b/environment/environment_test.go
@@ -7,20 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetWithDefaultUnsetVar(t *testing.T) {
-	os.Unsetenv("ABC")
-	value := GetWithDefault("ABC", "DEF")
-
-	assert.Equal(t, "DEF", value)
-}
-
-func TestGetWithDefaultSetVar(t *testing.T) {
-	os.Setenv("ABC", "VAL")
-	value := GetWithDefault("ABC", "DEF")
-
-	assert.Equal(t, "VAL", value)
-}
-
 func TestGetRequiredSet(t *testing.T) {
 	os.Setenv("ABC", "VAL")
 	value, err := GetRequired("ABC")

--- a/redis/cluster.go
+++ b/redis/cluster.go
@@ -64,16 +64,13 @@ type clusterConfig struct {
 func FromEnvOrFatal() RedisConfig {
 	cfg := clusterConfig{}
 
-	cfg.Size = env.GetIntWithDefault(RedisClusterSizeEnvSuffix, -1)
+	cfg.Size = env.GetIntOrFatal(RedisClusterSizeEnvSuffix)
 	cfg.namespace = env.GetOrFatal(RedisNamespaceEnvSuffix)
 
 	if cfg.Size == -1 {
 		cfg.options.Addr = env.GetOrFatal(RedisNodeAddressSuffix)
 		cfg.options.DB = env.GetIntOrFatal(RedisDBSuffix)
-		cfg.options.Password = env.ReadFileWithDefaultOrFatal(
-			env.GetWithDefault(RedisPasswordSuffix, ""),
-			"",
-		)
+		cfg.options.Password = env.ReadIndirectOrFatal(RedisPasswordSuffix)
 		return &cfg
 	}
 


### PR DESCRIPTION
Environment variables for services must be defined in the helm charts
even if it is a default value.


AB#8302