### PR TITLE
add WithRenewalTime opt to Receiver

### DIFF
--- a/azbus/message.go
+++ b/azbus/message.go
@@ -33,7 +33,7 @@ var (
 	ErrPeekLockTimeout = errors.New("peeklock deadline reached")
 )
 
-func setTimeout(ctx context.Context, log Logger, msg *ReceivedMessage) (context.Context, context.CancelFunc, time.Duration) {
+func (r *Receiver) setTimeout(ctx context.Context, log Logger, msg *ReceivedMessage) (context.Context, context.CancelFunc, time.Duration) {
 
 	var cancel context.CancelFunc
 
@@ -46,7 +46,7 @@ func setTimeout(ctx context.Context, log Logger, msg *ReceivedMessage) (context.
 		return ctx, cancel, maxDuration
 	}
 
-	ctx, cancel = context.WithTimeoutCause(ctx, RenewalTime, ErrPeekLockTimeout)
+	ctx, cancel = context.WithTimeoutCause(ctx, r.Cfg.RenewMessageTime, ErrPeekLockTimeout)
 	log.Infof("could not get lock deadline from message, using fixed timeout %v", ctx)
-	return ctx, cancel, RenewalTime
+	return ctx, cancel, r.Cfg.RenewMessageTime
 }

--- a/azbus/receiver.go
+++ b/azbus/receiver.go
@@ -85,6 +85,7 @@ type ReceiverConfig struct {
 	// See azbus/receiver.go
 	NumberOfReceivedMessages int
 	RenewMessageLock         bool
+	RenewMessageTime         time.Duration
 
 	// If a deadletter receiver then this is true
 	Deadletter bool
@@ -111,6 +112,19 @@ func WithHandler(h Handler) ReceiverOption {
 	}
 }
 
+// WithRenewalTime takes an optional time to renew the peek lock. This should be comfortably less
+// than the peek lock timeout. For example: the default peek lock timeout is 60s and the default
+// renewal time is 50s.
+//
+// Note! Only use this if you know what you're doing and you require custom timeout behaviour. The
+// peek lock timeout is specified in terraform configs currently, as it is a property of
+// subscriptions or queues.
+func WithRenewalTime(t int) ReceiverOption {
+	return func(r *Receiver) {
+		r.Cfg.RenewMessageTime = time.Duration(t) * time.Second
+	}
+}
+
 func NewReceiver(log Logger, cfg ReceiverConfig, opts ...ReceiverOption) *Receiver {
 	var options *azservicebus.ReceiverOptions
 	if cfg.Deadletter {
@@ -128,6 +142,11 @@ func NewReceiver(log Logger, cfg ReceiverConfig, opts ...ReceiverOption) *Receiv
 	r.log = log.WithIndex("receiver", r.String())
 	for _, opt := range opts {
 		opt(&r)
+	}
+
+	// Set this to a default that corresponds to the az servicebus default peek-lock timeout
+	if r.Cfg.RenewMessageTime == 0 {
+		r.Cfg.RenewMessageTime = RenewalTime
 	}
 
 	return &r
@@ -186,7 +205,7 @@ func (r *Receiver) elapsed(ctx context.Context, count int, total int, maxDuratio
 func (r *Receiver) receiverRenewMessageLock(ctx context.Context, count int, msg *ReceivedMessage) {
 	var err error
 
-	ticker := time.NewTicker(RenewalTime)
+	ticker := time.NewTicker(r.Cfg.RenewMessageTime)
 
 	var counter int
 	r.log.Debugf("RenewMessageLock %d started", count)

--- a/azbus/receiver.go
+++ b/azbus/receiver.go
@@ -282,7 +282,7 @@ func (r *Receiver) ReceiveMessages(handler Handler) error {
 				if r.Cfg.RenewMessageLock {
 					rctx = fctx
 				} else {
-					rctx, rcancel, maxDuration = setTimeout(fctx, r.log, msg)
+					rctx, rcancel, maxDuration = r.setTimeout(fctx, r.log, msg)
 					defer rcancel()
 				}
 				elapsedErr := r.elapsed(rctx, i+1, total, maxDuration, msg, handler)


### PR DESCRIPTION
to support custom peek lock timeouts, we also
need to adjust the lock renewal time.

Part of: [AB#8615](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/8615)

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>