### PR TITLE
Fix accidental copy of mutex

### DIFF
--- a/httpserver/httpserver.go
+++ b/httpserver/httpserver.go
@@ -28,7 +28,7 @@ func NewHTTPServer(log Logger, name string, port string, handler http.Handler) *
 	m.log = log.WithIndex("httpserver", m.String())
 	// It is preferable to return a copy rather than a reference. Unfortunately http.Server has an
 	// internal mutex and this cannot or should not be copied so we will return a reference instead.
-	log.Debugf("HTTPServer %v", m)
+	log.Debugf("HTTPServer")
 	return &m
 }
 


### PR DESCRIPTION
'task qa-basic' revealed an accidental copy of a mutex.

[AB#8365](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/8365)
