### PR TITLE
Dev/robin/8656 blob etag support for forestrie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .task/
 .local/
+.vscode/

--- a/azblob/accessconditions.go
+++ b/azblob/accessconditions.go
@@ -32,6 +32,7 @@ func storerOptionConditions(options *StorerOptions) (azStorageBlob.BlobAccessCon
 		blobAccessConditions.ModifiedAccessConditions.IfNoneMatch = &options.etag
 	case TagsWhere:
 		blobAccessConditions.ModifiedAccessConditions.IfTags = &options.etag
+	default:
 	}
 	return blobAccessConditions, nil
 }

--- a/azblob/accessconditions.go
+++ b/azblob/accessconditions.go
@@ -34,5 +34,12 @@ func storerOptionConditions(options *StorerOptions) (azStorageBlob.BlobAccessCon
 		blobAccessConditions.ModifiedAccessConditions.IfTags = &options.etag
 	default:
 	}
+	switch options.sinceCondition {
+	case IfConditionModifiedSince:
+		blobAccessConditions.ModifiedAccessConditions.IfModifiedSince = options.since
+	case IfConditionUnmodifiedSince:
+		blobAccessConditions.ModifiedAccessConditions.IfUnmodifiedSince = options.since
+	default:
+	}
 	return blobAccessConditions, nil
 }

--- a/azblob/accessconditions.go
+++ b/azblob/accessconditions.go
@@ -1,0 +1,37 @@
+package azblob
+
+import (
+	"errors"
+
+	azStorageBlob "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+)
+
+func storerOptionConditions(options *StorerOptions) (azStorageBlob.BlobAccessConditions, error) {
+
+	var blobAccessConditions azStorageBlob.BlobAccessConditions
+	if options.leaseID == "" && options.etagCondition == EtagNotUsed {
+		return blobAccessConditions, nil
+	}
+	if options.etag == "" && options.etagCondition != EtagNotUsed {
+		return blobAccessConditions, errors.New("etag value missing")
+	}
+
+	blobAccessConditions = azStorageBlob.BlobAccessConditions{}
+	if options.leaseID != "" {
+		blobAccessConditions.LeaseAccessConditions = &azStorageBlob.LeaseAccessConditions{
+			LeaseID: &options.leaseID,
+		}
+	}
+
+	blobAccessConditions.ModifiedAccessConditions = &azStorageBlob.ModifiedAccessConditions{}
+
+	switch options.etagCondition {
+	case ETagMatch:
+		blobAccessConditions.ModifiedAccessConditions.IfMatch = &options.etag
+	case ETagNoneMatch:
+		blobAccessConditions.ModifiedAccessConditions.IfNoneMatch = &options.etag
+	case TagsWhere:
+		blobAccessConditions.ModifiedAccessConditions.IfTags = &options.etag
+	}
+	return blobAccessConditions, nil
+}

--- a/azblob/bytesreadercloser.go
+++ b/azblob/bytesreadercloser.go
@@ -1,0 +1,18 @@
+package azblob
+
+import "bytes"
+
+type BytesReaderCloser struct {
+	*bytes.Reader
+}
+
+func NewBytesReaderCloser(b []byte) *BytesReaderCloser {
+	r := &BytesReaderCloser{
+		Reader: bytes.NewReader(b),
+	}
+	return r
+}
+
+func (io *BytesReaderCloser) Close() error {
+	return nil
+}

--- a/azblob/bytesreadercloser.go
+++ b/azblob/bytesreadercloser.go
@@ -2,17 +2,19 @@ package azblob
 
 import "bytes"
 
-type BytesReaderCloser struct {
+// BytesSeekableReader closer provides reader that has a No-Op Close and a
+// usuable Seek. Because we need Seek, we can't use ioutil.NopCloser
+type BytesSeekableReaderCloser struct {
 	*bytes.Reader
 }
 
-func NewBytesReaderCloser(b []byte) *BytesReaderCloser {
-	r := &BytesReaderCloser{
+func NewBytesReaderCloser(b []byte) *BytesSeekableReaderCloser {
+	r := &BytesSeekableReaderCloser{
 		Reader: bytes.NewReader(b),
 	}
 	return r
 }
 
-func (io *BytesReaderCloser) Close() error {
+func (io *BytesSeekableReaderCloser) Close() error {
 	return nil
 }

--- a/azblob/download.go
+++ b/azblob/download.go
@@ -7,13 +7,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/textproto"
-	"strconv"
 
 	azStorageBlob "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 
 	"github.com/rkvst/go-rkvstcommon/logger"
-	"github.com/rkvst/go-rkvstcommon/scannedstatus"
 )
 
 const (
@@ -39,6 +36,7 @@ func (azp *Storer) getTags(
 		logger.Sugar.Debugf("getTags BlockBlob Client %s error: %v", identity, err)
 		return nil, ErrorFromError(err)
 	}
+
 	resp, err := blobClient.GetTags(ctx, nil)
 	if err != nil {
 		logger.Sugar.Debugf("getTags BlockBlob URL %s error: %v", identity, err)
@@ -74,20 +72,6 @@ func (azp *Storer) getMetadata(
 	return resp.Metadata, nil
 }
 
-type ReaderResponse struct {
-	Reader            io.ReadCloser
-	HashValue         string
-	MimeType          string
-	Size              int64
-	Tags              map[string]string
-	TimestampAccepted string
-	ScannedStatus     string
-	ScannedBadReason  string
-	ScannedTimestamp  string
-
-	BlobClient *azStorageBlob.BlobClient
-}
-
 // Reader creates a reader.
 func (azp *Storer) Reader(
 	ctx context.Context,
@@ -105,13 +89,9 @@ func (azp *Storer) Reader(
 	logger.Sugar.Debugf("Reader BlockBlob URL %s", identity)
 
 	resp := &ReaderResponse{}
-	var blobAccessConditions azStorageBlob.BlobAccessConditions
-	if options.leaseID != "" {
-		blobAccessConditions = azStorageBlob.BlobAccessConditions{
-			LeaseAccessConditions: &azStorageBlob.LeaseAccessConditions{
-				LeaseID: &options.leaseID,
-			},
-		}
+	blobAccessConditions, err := storerOptionConditions(options)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(options.tags) > 0 || options.getTags {
@@ -127,6 +107,9 @@ func (azp *Storer) Reader(
 		resp.Tags = tags
 	}
 
+	// XXX: TODO this should be done with access conditions. this is racy as it
+	// stands. azure guarantees the tags for a blob read after write is
+	// consistent. we can't take advantage of that while this remains racy.
 	for k, requiredValue := range options.tags {
 		blobValue, ok := resp.Tags[k]
 		if !ok {
@@ -139,7 +122,9 @@ func (azp *Storer) Reader(
 		}
 	}
 
-	if options.getMetadata == OnlyMetadata || options.getMetadata == BothMetadataAndBlob {
+	// If we are *only* getting metadata, issue a distinct request. Otherwise we
+	// get it from the download response.
+	if options.getMetadata == OnlyMetadata {
 		metaData, metadataErr := azp.getMetadata(
 			ctx,
 			identity,
@@ -148,19 +133,9 @@ func (azp *Storer) Reader(
 			logger.Sugar.Infof("cannot get metadata: %v", metadataErr)
 			return nil, metadataErr
 		}
-		logger.Sugar.Debugf("blob metadata %v", metaData)
-		size, parseErr := strconv.ParseInt(metaData[textproto.CanonicalMIMEHeaderKey(SizeKey)], 10, 64)
-		if parseErr != nil {
-			logger.Sugar.Infof("cannot get size value: %v", parseErr)
-			return nil, parseErr
+		if parseErr := readerResponseMetadata(resp, metaData); parseErr != nil {
+			return nil, err
 		}
-		resp.Size = size
-		resp.HashValue = metaData[textproto.CanonicalMIMEHeaderKey(HashKey)]
-		resp.MimeType = metaData[textproto.CanonicalMIMEHeaderKey(MimeKey)]
-		resp.TimestampAccepted = metaData[textproto.CanonicalMIMEHeaderKey(TimeKey)]
-		resp.ScannedStatus = scannedstatus.FromString(metaData[textproto.CanonicalMIMEHeaderKey(scannedstatus.Key)]).String()
-		resp.ScannedBadReason = metaData[textproto.CanonicalMIMEHeaderKey(scannedstatus.BadReason)]
-		resp.ScannedTimestamp = metaData[textproto.CanonicalMIMEHeaderKey(scannedstatus.Timestamp)]
 	}
 
 	if options.getMetadata == OnlyMetadata {
@@ -180,12 +155,27 @@ func (azp *Storer) Reader(
 			Count:                &countToEnd,
 		},
 	)
+
 	if err != nil && err == io.EOF { // nolint
 		logger.Sugar.Infof("cannot get blob body: %v", err)
 		return nil, ErrorFromError(err)
 	}
-	resp.Reader = get.Body(nil)
-	return resp, nil
+
+	normaliseReaderResponseErr(err, resp)
+	if err == nil {
+		// We *always* copy the metadata into the response
+		downloadReaderResponse(get, resp)
+
+		// for backwards compat, we only process the metadata on request
+		if options.getMetadata == BothMetadataAndBlob {
+			readerResponseMetadata(resp, resp.Metadata)
+		}
+	}
+
+	if get.RawResponse != nil {
+		resp.Reader = get.Body(nil)
+	}
+	return resp, err
 }
 
 func (r *ReaderResponse) DownloadToWriter(w io.Writer) error {

--- a/azblob/download.go
+++ b/azblob/download.go
@@ -168,7 +168,7 @@ func (azp *Storer) Reader(
 
 		// for backwards compat, we only process the metadata on request
 		if options.getMetadata == BothMetadataAndBlob {
-			readerResponseMetadata(resp, resp.Metadata)
+			_ = readerResponseMetadata(resp, resp.Metadata) // the parse error is benign
 		}
 	}
 

--- a/azblob/error.go
+++ b/azblob/error.go
@@ -59,3 +59,20 @@ func (e *Error) StatusCode() int {
 	logger.Sugar.Debugf("Return InternalServerError")
 	return http.StatusInternalServerError
 }
+
+// StorageErrorCode returns the underlying azure storage ErrorCode string eg "BlobNotFound"
+func (e *Error) StorageErrorCode() string {
+	var terr *azStorageBlob.StorageError
+	if errors.As(e.err, &terr) {
+		if terr.ErrorCode != "" {
+			return string(terr.ErrorCode)
+		}
+	}
+	return ""
+}
+
+// IsConditionNotMet returns true if the err is the storage code indicating that
+// a If- header predicate (eg ETag) was not met
+func (e *Error) IsConditionNotMet() bool {
+	return e.StorageErrorCode() == string(azStorageBlob.StorageErrorCodeConditionNotMet)
+}

--- a/azblob/etags_test.go
+++ b/azblob/etags_test.go
@@ -45,6 +45,7 @@ func TestPutIfMatch(t *testing.T) {
 
 	originalValue := []byte("ORIGINAL_VALUE")
 	secondValue := []byte("SECOND_VALUE")
+	thirdValue := []byte("THIRD_VALUE")
 
 	// establish the original value
 	wr, err := storer.Put(context.Background(), blobName, NewBytesReaderCloser(originalValue))
@@ -74,6 +75,17 @@ func TestPutIfMatch(t *testing.T) {
 	// check the error is exactly as we expect
 	if !ErrorFromError(err).IsConditionNotMet() {
 		t.Fatalf("expected ConditionNotMet err, got: %v", err)
+	}
+
+	_, err = storer.Put(
+		context.Background(), blobName, NewBytesReaderCloser(thirdValue), WithEtagMatch(*wr.ETag))
+	if err == nil {
+		t.Fatalf("overwrote second value with wrong etag")
+	}
+	_, err = storer.Put(
+		context.Background(), blobName, NewBytesReaderCloser(thirdValue), WithEtagMatch(*wr2.ETag))
+	if err != nil {
+		t.Fatalf("failed put third value: %v", err)
 	}
 }
 

--- a/azblob/etags_test.go
+++ b/azblob/etags_test.go
@@ -1,0 +1,143 @@
+package azblob
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rkvst/go-rkvstcommon/logger"
+)
+
+func uniqueTestName(testName string, t *testing.T) string {
+	uid, err := uuid.NewRandom()
+	if err != nil {
+		t.Fatalf("%v", err)
+		return testName
+	}
+	return fmt.Sprintf("%s-%s", testName, uid.String())
+}
+
+// Tests covering the setting and behaviour of etags. Requires the azurite emulator to be running
+
+// Test_PutIfMatch checks the handling of WithETagMatch, which is typically used
+// to re-concile racing updates by guaranteeing a single winner.
+func TestPutIfMatch(t *testing.T) {
+
+	logger.New("NOOP")
+	defer logger.OnExit()
+
+	testName := uniqueTestName("PutIfMatch", t)
+
+	storer, err := NewDev(NewDevConfigFromEnv(), "devcontainer")
+	if err != nil {
+		t.Fatalf("failed to connect to blob store emulator: %v", err)
+	}
+	client := storer.GetServiceClient()
+	// This will error if it exists and that is fine
+	_, err = client.CreateContainer(context.Background(), "devcontainer", nil)
+	if err != nil {
+		s := err.Error()
+		logger.Sugar.Infof("benign err: %v, %s", err, s)
+	}
+
+	blobName := fmt.Sprintf("tests/blobs/%s-%d", testName, 1)
+
+	originalValue := []byte("ORIGINAL_VALUE")
+	secondValue := []byte("SECOND_VALUE")
+
+	// establish the original value
+	wr, err := storer.Put(context.Background(), blobName, NewBytesReaderCloser(originalValue))
+	if err != nil {
+		t.Fatalf("failed put original value: %v", err)
+	}
+
+	// put the updated value only if we match the original value
+	wr2, err := storer.Put(
+		context.Background(), blobName, NewBytesReaderCloser(secondValue), WithEtagMatch(*wr.ETag))
+	if err != nil {
+		t.Fatalf("failed put second value: %v", err)
+	}
+
+	// read back only if it matches the new value
+	_, err = storer.Reader(context.Background(), blobName, WithEtagMatch(*wr2.ETag))
+	if err != nil {
+		t.Fatalf("failed to read value with updated ETag: %v", err)
+	}
+
+	// expect an error if we use the stale value
+	wr3, err := storer.Reader(context.Background(), blobName, WithEtagMatch(*wr.ETag))
+	if err == nil {
+		t.Fatalf("updated content despite stale etag")
+		logger.Sugar.Infof("%s", wr3.XMsErrorCode)
+	}
+	// check the error is exactly as we expect
+	if !ErrorFromError(err).IsConditionNotMet() {
+		t.Fatalf("expected ConditionNotMet err, got: %v", err)
+	}
+}
+
+// Test_ReadIfNoneMatch tests the handling of the WitEtagNoneMatch option
+func Test_ReadIfNoneMatch(t *testing.T) {
+
+	logger.New("NOOP")
+	defer logger.OnExit()
+
+	testName := uniqueTestName("ReadIfNoneMatch", t)
+
+	storer, err := NewDev(NewDevConfigFromEnv(), "devcontainer")
+	if err != nil {
+		t.Fatalf("failed to connect to blob store emulator: %v", err)
+	}
+	client := storer.GetServiceClient()
+	// This will error if it exists and that is fine
+	_, _ = client.CreateContainer(context.Background(), "devcontainer", nil)
+
+	blobName := fmt.Sprintf("%s-%s", testName, "blob")
+
+	originalValue := []byte("ORIGINAL_VALUE")
+	secondValue := []byte("SECOND_VALUE")
+
+	wr, err := storer.Put(context.Background(), blobName, NewBytesReaderCloser(originalValue))
+	if err != nil {
+		t.Fatalf("failed put original value: %v", err)
+	}
+
+	// change the value
+	wr2, err := storer.Put(
+		context.Background(), blobName, NewBytesReaderCloser(secondValue))
+	if err != nil {
+		t.Fatalf("failed put second value: %v", err)
+	}
+	logger.Sugar.Infof("%v", wr2.ETag)
+
+	// check we *fail* to get it when the matching etag is used
+	wr3, err := storer.Reader(context.Background(), blobName, WithEtagNoneMatch(*wr2.ETag))
+	if err != nil {
+		// For reads we _dont_ get an err (as we do for Put's), instead we have to examine the response.
+		t.Fatalf("error reading with stale etag: %v", err)
+	}
+	if !wr3.ConditionNotMet() {
+		t.Fatalf("expected ConditionNotMet")
+	}
+
+	// check we do get it when the stale etag is used
+	wr4, err := storer.Reader(context.Background(), blobName, WithEtagNoneMatch(*wr.ETag))
+	if err != nil {
+		t.Fatalf("failed to read fresh value predicated on stale etag: %v", err)
+	}
+	// Note: unless using the If- headers
+	if !wr4.Ok() {
+		t.Fatalf("expected Ok")
+	}
+
+	wr, err = storer.Put(context.Background(), blobName, NewBytesReaderCloser(secondValue))
+	if err != nil {
+		t.Fatalf("failed put second value: %v", err)
+	}
+
+	_, err = storer.Put(context.Background(), blobName, NewBytesReaderCloser(originalValue))
+	if err != nil {
+		t.Fatalf("failed put original value: %v", err)
+	}
+}

--- a/azblob/etags_test.go
+++ b/azblob/etags_test.go
@@ -69,8 +69,7 @@ func TestPutIfMatch(t *testing.T) {
 	// expect an error if we use the stale value
 	wr3, err := storer.Reader(context.Background(), blobName, WithEtagMatch(*wr.ETag))
 	if err == nil {
-		t.Fatalf("updated content despite stale etag")
-		logger.Sugar.Infof("%s", wr3.XMsErrorCode)
+		t.Fatalf("updated content despite stale etag: %s", wr3.XMsErrorCode)
 	}
 	// check the error is exactly as we expect
 	if !ErrorFromError(err).IsConditionNotMet() {
@@ -143,7 +142,7 @@ func Test_ReadIfNoneMatch(t *testing.T) {
 		t.Fatalf("expected Ok")
 	}
 
-	wr, err = storer.Put(context.Background(), blobName, NewBytesReaderCloser(secondValue))
+	_, err = storer.Put(context.Background(), blobName, NewBytesReaderCloser(secondValue))
 	if err != nil {
 		t.Fatalf("failed put second value: %v", err)
 	}

--- a/azblob/readresponse.go
+++ b/azblob/readresponse.go
@@ -69,6 +69,7 @@ func normaliseReaderResponseErr(err error, rr *ReaderResponse) {
 		case azStorageBlob.StorageErrorCodeConditionNotMet:
 			rr.Status = "304 " + string(terr.ErrorCode)
 			rr.StatusCode = 304
+		default:
 		}
 	}
 }

--- a/azblob/readresponse.go
+++ b/azblob/readresponse.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/textproto"
 	"strconv"
+	"time"
 
 	azStorageBlob "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/rkvst/go-rkvstcommon/logger"
@@ -27,6 +28,7 @@ type ReaderResponse struct {
 	// The following are copied as appropriate from the azure sdk response.
 	// See also WriterResponse
 	ETag         *string
+	LastModified *time.Time
 	Metadata     map[string]string // x-ms-meta header
 	StatusCode   int               // For If- header fails, err can be nil and code can be 304
 	Status       string
@@ -83,6 +85,7 @@ func downloadReaderResponse(r azStorageBlob.BlobDownloadResponse, rr *ReaderResp
 	if ok && len(value) > 0 {
 		rr.XMsErrorCode = value[0]
 	}
+	rr.LastModified = r.LastModified
 	rr.ETag = r.ETag
 	rr.Metadata = r.Metadata
 }

--- a/azblob/readresponse.go
+++ b/azblob/readresponse.go
@@ -1,0 +1,106 @@
+package azblob
+
+import (
+	"errors"
+	"io"
+	"net/textproto"
+	"strconv"
+
+	azStorageBlob "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/rkvst/go-rkvstcommon/logger"
+	"github.com/rkvst/go-rkvstcommon/scannedstatus"
+)
+
+type ReaderResponse struct {
+	Reader            io.ReadCloser
+	HashValue         string
+	MimeType          string
+	Size              int64
+	Tags              map[string]string
+	TimestampAccepted string
+	ScannedStatus     string
+	ScannedBadReason  string
+	ScannedTimestamp  string
+
+	BlobClient *azStorageBlob.BlobClient
+
+	// The following are copied as appropriate from the azure sdk response.
+	// See also WriterResponse
+	ETag         *string
+	Metadata     map[string]string // x-ms-meta header
+	StatusCode   int               // For If- header fails, err can be nil and code can be 304
+	Status       string
+	XMsErrorCode string // will be "ConditioNotMet" for If- header predicate fails, even when err is nil
+}
+
+func (r *ReaderResponse) ConditionNotMet() bool {
+	return r.XMsErrorCode == string(azStorageBlob.StorageErrorCodeConditionNotMet)
+}
+
+// Ok returns true if the http status was 200 or 201
+// This method is provided for use in combination with specific headers like
+// If-Match and ETags conditions.  In thos circumstances we often get err=nil
+// but no content.
+func (r *ReaderResponse) Ok() bool {
+	return r.StatusCode == 200 || r.StatusCode == 201
+}
+
+const (
+	xMsErrorCodeHeader = "X-Ms-Error-Code"
+)
+
+// normaliseReaderResponseErr propagates appropriate err details to the response
+// this makes it easier to do consistent checking of responses when using ETags
+// and other conditional header features.
+//
+// Does nothing unless err can be handled As(azure-sdk.StorageError)
+func normaliseReaderResponseErr(err error, rr *ReaderResponse) {
+	if err == nil {
+		return
+	}
+
+	var terr *azStorageBlob.StorageError
+	if !errors.As(err, &terr) {
+		return
+	}
+	if terr.ErrorCode != "" {
+		rr.XMsErrorCode = string(terr.ErrorCode)
+		switch terr.ErrorCode {
+		case azStorageBlob.StorageErrorCodeConditionNotMet:
+			rr.Status = "304 " + string(terr.ErrorCode)
+			rr.StatusCode = 304
+		}
+	}
+}
+
+// downloadReaderResponse copies accross the azure sdk response values that are
+// meaningful to our supported api
+func downloadReaderResponse(r azStorageBlob.BlobDownloadResponse, rr *ReaderResponse) {
+	rr.Status = r.RawResponse.Status
+	rr.StatusCode = r.RawResponse.StatusCode
+	value, ok := r.RawResponse.Header[xMsErrorCodeHeader]
+	if ok && len(value) > 0 {
+		rr.XMsErrorCode = value[0]
+	}
+	rr.ETag = r.ETag
+	rr.Metadata = r.Metadata
+}
+
+// readerResponseMetadata processes and conditions values from the metadata we have specific support for.
+func readerResponseMetadata(resp *ReaderResponse, metaData map[string]string) error {
+	size, parseErr := strconv.ParseInt(metaData[textproto.CanonicalMIMEHeaderKey(SizeKey)], 10, 64)
+	if parseErr != nil {
+		logger.Sugar.Infof("cannot get size value: %v", parseErr)
+		return parseErr
+	}
+	resp.Size = size
+	resp.HashValue = metaData[textproto.CanonicalMIMEHeaderKey(HashKey)]
+	resp.MimeType = metaData[textproto.CanonicalMIMEHeaderKey(MimeKey)]
+	resp.TimestampAccepted = metaData[textproto.CanonicalMIMEHeaderKey(TimeKey)]
+	resp.ScannedStatus = scannedstatus.FromString(metaData[textproto.CanonicalMIMEHeaderKey(scannedstatus.Key)]).String()
+	resp.ScannedBadReason = metaData[textproto.CanonicalMIMEHeaderKey(scannedstatus.BadReason)]
+	resp.ScannedTimestamp = metaData[textproto.CanonicalMIMEHeaderKey(scannedstatus.Timestamp)]
+	// Note: it is fine if these are the same instances
+	resp.Metadata = metaData
+	return nil
+}

--- a/azblob/storerazurite.go
+++ b/azblob/storerazurite.go
@@ -25,7 +25,7 @@ const (
 
 	azuriteWellKnownKey             string = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
 	azuriteWellKnownAccount         string = "devstoreaccount1"
-	azuriteWellKnownBlobEndpointURL string = "http://127.0.0.1:10000/"
+	azuriteWellKnownBlobEndpointURL string = "http://127.0.0.1:10000/devstoreaccount1/"
 	azuriteResourceGroup            string = "azurite-emulator"
 	azuriteSubscription             string = "azurite-emulator"
 )
@@ -42,7 +42,7 @@ func NewDevConfigFromEnv() DevConfig {
 	return DevConfig{
 		AccountName: devVarWithDefault(azureStorageAccountVar, azuriteWellKnownAccount),
 		Key:         devVarWithDefault(azureStorageKeyVar, azuriteWellKnownKey),
-		URL:         devVarWithDefault(azuriteBlobEndpointURLVar, azuriteWellKnownKey),
+		URL:         devVarWithDefault(azuriteBlobEndpointURLVar, azuriteWellKnownBlobEndpointURL),
 	}
 }
 

--- a/azblob/writeresponse.go
+++ b/azblob/writeresponse.go
@@ -1,0 +1,36 @@
+package azblob
+
+import (
+	"time"
+
+	azStorageBlob "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+)
+
+type WriteResponse struct {
+	HashValue         string
+	MimeType          string
+	Size              int64
+	TimestampAccepted string
+
+	// The following fields are copied from the sdk response. nil pointers mean
+	// 'not set'.  Note that different azure blob sdk write mode apis (put,
+	// create, stream) etc return different generated types. So we copy only the
+	// fields which make sense into this unified type. And we only copy values
+	// which can be made use of in the api presented by this package.
+	ETag         *string
+	LastModified *time.Time
+}
+
+func uploadStreamWriteResponse(r azStorageBlob.BlockBlobCommitBlockListResponse) *WriteResponse {
+	w := WriteResponse{
+		ETag: r.ETag,
+	}
+	return &w
+}
+
+func uploadWriteResponse(r azStorageBlob.BlockBlobUploadResponse) *WriteResponse {
+	w := WriteResponse{
+		ETag: r.ETag,
+	}
+	return &w
+}

--- a/azblob/writeresponse.go
+++ b/azblob/writeresponse.go
@@ -45,6 +45,7 @@ func normaliseWriteResponseErr(err error, wr *WriteResponse) {
 		case azStorageBlob.StorageErrorCodeConditionNotMet:
 			wr.Status = "304 " + string(terr.ErrorCode)
 			wr.StatusCode = 304
+		default:
 		}
 	}
 }

--- a/azblob/writeresponse.go
+++ b/azblob/writeresponse.go
@@ -1,6 +1,7 @@
 package azblob
 
 import (
+	"errors"
 	"time"
 
 	azStorageBlob "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -19,12 +20,46 @@ type WriteResponse struct {
 	// which can be made use of in the api presented by this package.
 	ETag         *string
 	LastModified *time.Time
+	StatusCode   int // For If- header fails, err can be nil and code can be 304
+	Status       string
+	XMsErrorCode string // will be "ConditioNotMet" for If- header predicate fails, even when err is nil
+}
+
+// normaliseWriteResponseErr propagates appropriate err details to the response
+// this makes it easier to do consistent checking of responses when using ETags
+// and other conditional header features.
+//
+// Does nothing unless err can be handled As(azure-sdk.StorageError)
+func normaliseWriteResponseErr(err error, wr *WriteResponse) {
+	if err == nil {
+		return
+	}
+
+	var terr *azStorageBlob.StorageError
+	if !errors.As(err, &terr) {
+		return
+	}
+	if terr.ErrorCode != "" {
+		wr.XMsErrorCode = string(terr.ErrorCode)
+		switch terr.ErrorCode {
+		case azStorageBlob.StorageErrorCodeConditionNotMet:
+			wr.Status = "304 " + string(terr.ErrorCode)
+			wr.StatusCode = 304
+		}
+	}
 }
 
 func uploadStreamWriteResponse(r azStorageBlob.BlockBlobCommitBlockListResponse) *WriteResponse {
 	w := WriteResponse{
 		ETag: r.ETag,
 	}
+	w.Status = r.RawResponse.Status
+	w.StatusCode = r.RawResponse.StatusCode
+	value, ok := r.RawResponse.Header[xMsErrorCodeHeader]
+	if ok && len(value) > 0 {
+		w.XMsErrorCode = value[0]
+	}
+
 	return &w
 }
 
@@ -32,5 +67,12 @@ func uploadWriteResponse(r azStorageBlob.BlockBlobUploadResponse) *WriteResponse
 	w := WriteResponse{
 		ETag: r.ETag,
 	}
+	w.Status = r.RawResponse.Status
+	w.StatusCode = r.RawResponse.StatusCode
+	value, ok := r.RawResponse.Header[xMsErrorCodeHeader]
+	if ok && len(value) > 0 {
+		w.XMsErrorCode = value[0]
+	}
+
 	return &w
 }


### PR DESCRIPTION
feat: etag support for put & read blob

The introduction of ETag support makes it possible to do two things:

1. read/modify/write concurrency guards, so that values are written back
   only if the destination content hasn't been modified since being
   read.
2. Efficient cache refreshing without fetching the blob data. still
   requires request round trip, but no data is returned in the response
   if the content is unchanged since the last read.

1. is going to give us crash fault tollerance and race reconciliaiton
   for updating forestrie blobs.

behaviour change:

Previously Read swallowed any error that wasn't accompanied by an io.EOF
condition. This causes the return states to be very confusing when
dealint with If- header responses. The err is now returned in that case.

The arrangements to ensure body.Read is called remain as before

[AB#8656](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/8656)